### PR TITLE
add code in support of plotting plates >96-wells

### DIFF
--- a/bin/visualize_potential_cross_contamination.R
+++ b/bin/visualize_potential_cross_contamination.R
@@ -93,7 +93,6 @@ plate_list <- function(max_row, num_columns) {
         num_rows<-max_row
     }
     col_idx<-seq(1, num_columns, by=1)
-    #row_idx<-LETTERS[seq( from = 1, to = num_rows )]
     seq( from = 1, to = num_rows )
     row_idx<-unlist(lapply(seq( from = 1, to = num_rows ),rowNumToAlpha))
     wells<-expand.grid(row=row_idx,col=col_idx)


### PR DESCRIPTION
add code to `visualize_potential_cross_contamination.R` in support of (eventually) plotting plates >96-wells:
* `alphaToRowNum(row)`
  * Ex. `"ABA" -> 729`
* `rowNumToAlpha(row_num)`
  * Ex. `729 ->"ABA"`
* `plate_list(max_row, num_columns)`
  * accepts either alpha designation of last row or number of rows; Ex. for a 1536-well plate (32x48):
    * `plate_list("AF",48) # ["A1", "A2", ... "AF48"]`
    * `plate_list(32,48) # ["A1", "A2", ... "AF48"]`
  * Can also be used to return the ID of a given 1-indexed well number; Ex. for a 96-well plate (8x12):
    * `wells <- plate_list("H",12)`
    * `wells[28] # (slice gives "C4")`