### PR TITLE
update conda env to py3.9 to allow openssl version compatible with both samtools and python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@ ENV \
     PATH="$POLYPHONIA_PATH:$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # initiate conda environment
-RUN conda create -n $CONDA_DEFAULT_ENV python=3.8
+RUN mamba create -n $CONDA_DEFAULT_ENV python=3.9
 RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 
 # install specific tools and dependencies via conda
 COPY requirements-conda.txt /opt/docker
-RUN /bin/bash -c "set -e; sync; conda install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
+RUN /bin/bash -c "set -e; sync; mamba install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
 
 # install actual polyphonia scripts
 COPY bin/* $POLYPHONIA_PATH/


### PR DESCRIPTION
update conda env to py3.9 to allow openssl version compatible with both samtools and python; switch to mamba for faster conda env setup and package install